### PR TITLE
Tlv refactor

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to Serial Protocol - Python's Documentation!
    :caption: Contents:
 
    cobs.rst
+   tlv.rst
    utils.rst
 
 

--- a/docs/source/tlv.rst
+++ b/docs/source/tlv.rst
@@ -1,0 +1,9 @@
+TLV Packet
+==================
+
+.. toctree::
+
+.. automodule:: serial_protocol.tlv
+    :members:
+    :special-members: __init__
+    :undoc-members:

--- a/src/serial_protocol/tlv.py
+++ b/src/serial_protocol/tlv.py
@@ -5,21 +5,12 @@ from typing import Union
 from serial_protocol import utils
 
 
-class TLVValueReturnType(Enum):
-    """
-    Supported return types for decoding the value portion of a TLV packet.
-    """
-    BYTEARRAY = "bytearray"
-    INT = "int"
-    FLOAT = "float"
-
-
 class TLVPacket:
     """
     Type-Length-Value packet encoder and decoder.
 
     This class supports configurable field widths for both the data length and encode/decode value
-    fields using `ValueFormat`, and supports IEEE 754 float encoding via `FloatPrecision`.
+    fields using `ValueFormat`.
 
     Example:
         >>> tlv = TLVPacket()
@@ -30,7 +21,15 @@ class TLVPacket:
 
     def __init__(self,
                  max_data_length: utils.ValueFormat = utils.ValueFormat.UINT8):
+        """
+        Initialize a TLV packet encoder/decoder.
 
+        Args:
+            max_data_length (ValueFormat): Format used to encode the length field.
+
+        Raises:
+            ValueError: If the format is not an unsigned integer type.
+        """
         self.__max_data_length = utils.ValueFormat.coerce(max_data_length)
         if not self.max_data_length.is_uint():
             raise ValueError("The max data length must be of category uint "
@@ -38,6 +37,7 @@ class TLVPacket:
 
     @property
     def max_data_length(self) -> utils.ValueFormat:
+        """Format used to encode the length field (must be an unsigned integer)."""
         return self.__max_data_length
 
     @max_data_length.setter
@@ -54,6 +54,7 @@ class TLVPacket:
         Args:
             type_ (int | bytearray): Type field (must fit in one byte).
             value_ (int | float | bytearray): Value field to encode.
+            format_ (ValueFormat): Format of the value.
 
         Returns:
             bytearray: Encoded TLV packet.
@@ -84,8 +85,8 @@ class TLVPacket:
             tuple[int, int, int|float|bytearray]: (type, length, decoded value)
 
         Raises:
-            TypeError: If inputs are of incorrect types.
-            ValueError: If the packet is malformed or decoding fails.
+            TypeError: If input is not a bytearray.
+            ValueError: If packet structure is invalid or decoding fails.
 
         Example:
             >>> tlv = TLVPacket()
@@ -112,7 +113,7 @@ class TLVPacket:
 
         value_bytes = packet[num_len_bytes + 1:]
 
-        # --- Handle decoding based on ValueFormat
+        # Handle decoding based on ValueFormat
         if value_format is None:
             value_ = value_bytes
         else:

--- a/src/serial_protocol/tlv.py
+++ b/src/serial_protocol/tlv.py
@@ -18,8 +18,8 @@ class TLVPacket:
     """
     Type-Length-Value packet encoder and decoder.
 
-    This class supports configurable field widths for both the length and value
-    fields using `MaxUInt`, and supports IEEE 754 float encoding via `FloatPrecision`.
+    This class supports configurable field widths for both the data length and encode/decode value
+    fields using `ValueFormat`, and supports IEEE 754 float encoding via `FloatPrecision`.
 
     Example:
         >>> tlv = TLVPacket()
@@ -29,41 +29,25 @@ class TLVPacket:
     """
 
     def __init__(self,
-                 max_data_length: utils.MaxUInt = utils.MaxUInt.UINT8,
-                 max_data_value: utils.MaxUInt = utils.MaxUInt.UINT8,
-                 float_byte_size: utils.FloatPrecision = utils.FloatPrecision.FLOAT32):
+                 max_data_length: utils.ValueFormat = utils.ValueFormat.UINT8):
 
-        self.__max_data_length = utils.coerce_enum(max_data_length, utils.MaxUInt)
-        self.__max_data_value = utils.coerce_enum(max_data_value, utils.MaxUInt)
-        self.__float_byte_size = utils.coerce_enum(float_byte_size, utils.FloatPrecision)
+        self.__max_data_length = utils.ValueFormat.coerce(max_data_length)
+        if not self.max_data_length.is_uint():
+            raise ValueError("The max data length must be of category uint "
+                             f"not {self.max_data_length.category}")
 
     @property
-    def max_data_length(self) -> utils.MaxUInt:
+    def max_data_length(self) -> utils.ValueFormat:
         return self.__max_data_length
 
     @max_data_length.setter
-    def max_data_length(self, value: utils.MaxUInt):
-        self.__max_data_length = utils.coerce_enum(value, utils.MaxUInt)
-
-    @property
-    def max_data_value(self) -> utils.MaxUInt:
-        return self.__max_data_value
-
-    @max_data_value.setter
-    def max_data_value(self, value: utils.MaxUInt):
-        self.__max_data_value = utils.coerce_enum(value, utils.MaxUInt)
-
-    @property
-    def float_byte_size(self) -> utils.FloatPrecision:
-        return self.__float_byte_size
-
-    @float_byte_size.setter
-    def float_byte_size(self, value: utils.FloatPrecision):
-        self.__float_byte_size = utils.coerce_enum(value, utils.FloatPrecision)
+    def max_data_length(self, value: utils.ValueFormat):
+        self.__max_data_length = utils.ValueFormat.coerce(value)
 
     def encode(self,
                type_: Union[int, bytearray],
-               value_: Union[int, float, bytearray]) -> bytearray:
+               value_: Union[int, float, bytearray],
+               format_: utils.ValueFormat = utils.ValueFormat.UINT8) -> bytearray:
         """
         Encode a TLV packet.
 
@@ -79,39 +63,38 @@ class TLVPacket:
             bytearray(b'\\x01\\x01\\x00\\x2a')
         """
         type_ = self._validate_and_convert_type(type_)
-        value_ = self._validate_and_convert_value(value_)
+        value_ = self._validate_and_convert_value(value_, format_)
         length_ = utils.int_to_bytearray(len(value_), self.max_data_length)
 
         return bytearray(type_ + length_ + value_)
 
     def decode(self,
                packet: bytearray,
-               return_value_as: TLVValueReturnType = TLVValueReturnType.BYTEARRAY
+               value_format: utils.ValueFormat | None = None
                ) -> tuple[int, int, Union[int, float, bytearray]]:
         """
         Decode a TLV packet and extract type, length, and value.
 
         Args:
             packet (bytearray): The TLV packet to decode.
-            return_value_as (TLVValueReturnType): Desired return type for the value.
+            value_format (ValueFormat, optional): If provided, decode the value accordingly.
+                                                If None, the value is returned as a raw bytearray.
 
         Returns:
             tuple[int, int, int|float|bytearray]: (type, length, decoded value)
 
         Raises:
             TypeError: If inputs are of incorrect types.
-            ValueError: If packet structure is invalid.
+            ValueError: If the packet is malformed or decoding fails.
 
         Example:
             >>> tlv = TLVPacket()
-            >>> pkt = tlv.encode(1, 123)
-            >>> tlv.decode(pkt, TLVValueReturnType.INT)
-            (1, 1, 123)
+            >>> pkt = tlv.encode(1, 3.14, ValueFormat.FLOAT32)
+            >>> tlv.decode(pkt, ValueFormat.FLOAT32)
+            (1, 4, 3.14)
         """
         if not isinstance(packet, bytearray):
             raise TypeError(f"Expected bytearray for packet, got {type(packet).__name__}")
-        if not isinstance(return_value_as, TLVValueReturnType):
-            raise TypeError(f"Expected TLVValueReturnType, got {type(return_value_as).__name__}")
 
         num_len_bytes = self.max_data_length.num_bytes
         if len(packet) < 1 + num_len_bytes:
@@ -124,28 +107,29 @@ class TLVPacket:
         if len(packet) != expected_total_len:
             raise ValueError(
                 f"Packet length mismatch: expected {expected_total_len} bytes "
-                f"(type=1, length field={length_}), got {len(packet)} bytes."
+                f"(type={type_}, length field={length_}), got {len(packet)} bytes."
             )
 
         value_bytes = packet[num_len_bytes + 1:]
-        if return_value_as == TLVValueReturnType.BYTEARRAY:
+
+        # --- Handle decoding based on ValueFormat
+        if value_format is None:
             value_ = value_bytes
-        elif return_value_as == TLVValueReturnType.INT:
-            value_ = utils.bytearray_to_int(value_bytes)
-        elif return_value_as == TLVValueReturnType.FLOAT:
-            value_ = self._decode_float(value_bytes)
         else:
-            raise ValueError(f"Unsupported return type: {return_value_as}")
+            value_format = utils.ValueFormat.coerce(value_format)
+            if value_format.is_uint():
+                value_ = utils.bytearray_to_int(value_bytes)
+            elif value_format.is_float():
+                if len(value_bytes) != value_format.num_bytes:
+                    raise ValueError(
+                        f"Expected {value_format.num_bytes} bytes for float format "
+                        f"{value_format.label}, got {len(value_bytes)} bytes."
+                    )
+                value_ = utils.bytearray_to_float(value_bytes, value_format)
+            else:
+                raise ValueError(f"Unsupported value format: {value_format}")
 
         return type_, length_, value_
-
-    def _decode_float(self, b: bytearray) -> float:
-        """Helper to decode float with byte size check."""
-        if len(b) != self.float_byte_size.num_bytes:
-            raise ValueError(
-                f"Float value length mismatch: expected {self.float_byte_size.num_bytes} bytes, got {len(b)}."
-            )
-        return utils.bytearray_to_float(b, self.float_byte_size)
 
     def _validate_and_convert_type(self, type_: Union[int, bytearray]) -> bytearray:
         """
@@ -166,19 +150,29 @@ class TLVPacket:
 
         raise TypeError("Input type_ must be an integer or a 1-byte bytearray.")
 
-    def _validate_and_convert_value(self, value_: Union[int, float, bytearray]) -> bytearray:
+    def _validate_and_convert_value(self,
+                                    value_: Union[int, float, bytearray],
+                                    format_: utils.ValueFormat) -> bytearray:
         """
         Validate and convert the value to a bytearray.
 
         Example:
-            >>> TLVPacket()._validate_and_convert_value(42)
+            >>> TLVPacket()._validate_and_convert_value(42, ValueFormat.UINT8)
             bytearray(b'*')
         """
-        if isinstance(value_, int):
-            return utils.int_to_bytearray(value_, self.max_data_value)
-        if isinstance(value_, float):
-            return utils.float_to_bytearray(value_, self.float_byte_size)
+        format_ = utils.ValueFormat.coerce(format_)
+
         if isinstance(value_, bytearray):
             return value_
 
-        raise TypeError("Input value_ must be an integer, float, or bytearray.")
+        if format_.is_float():
+            if not isinstance(value_, float):
+                raise TypeError(f"Expected float for format {format_.label}, got {type(value_).__name__}")
+            return utils.float_to_bytearray(value_, format_)
+
+        if format_.is_uint():
+            if not isinstance(value_, int):
+                raise TypeError(f"Expected integer for format {format_.label}, got {type(value_).__name__}")
+            return utils.int_to_bytearray(value_, format_)
+
+        raise TypeError(f"Unsupported format type: {format_.label}")

--- a/src/serial_protocol/utils.py
+++ b/src/serial_protocol/utils.py
@@ -15,10 +15,10 @@ class ValueFormat(Enum):
     Enumeration of supported value formats, including unsigned integers and IEEE 754 floats.
 
     Each member defines:
-    - The number of bytes
-    - The category ('uint' or 'float')
-    - A string label for documentation/debugging
-    - A struct format character (for float types)
+    - Number of bytes (1, 2, 4, or 8)
+    - Category: either 'uint' or 'float'
+    - A descriptive label (e.g., 'uint16')
+    - A format character used by `struct` (only for float types)
 
     Example:
         >>> ValueFormat.FLOAT32.num_bytes
@@ -34,30 +34,37 @@ class ValueFormat(Enum):
 
     @property
     def num_bytes(self) -> int:
+        """Number of bytes used to store the value."""
         return self.value[0]
 
     @property
     def category(self) -> str:
+        """The category of the value type: 'uint' or 'float'."""
         return self.value[1]
 
     @property
     def label(self) -> str:
+        """A human-readable string label for the format."""
         return self.value[2]
 
     @property
     def format_char(self) -> str:
+        """Struct format character used for float encoding/decoding."""
         return self.value[3]
 
     @property
     def max_value(self) -> int:
+        """Maximum value (only valid for unsigned int types)."""
         if self.is_uint():
-            return 2**(self.num_bytes*8) - 1
+            return 2**(self.num_bytes * 8) - 1
         return None
 
     def is_uint(self) -> bool:
+        """Return True if format represents an unsigned integer."""
         return self.category == "uint"
 
     def is_float(self) -> bool:
+        """Return True if format represents a float."""
         return self.category == "float"
 
     @classmethod
@@ -66,13 +73,13 @@ class ValueFormat(Enum):
         Ensure the input is a ValueFormat enum instance.
 
         Args:
-            value (ValueFormat or str): Value to convert, string should be equal to label.
+            value (ValueFormat or str): Value to convert. If str, must match a member's label.
 
         Returns:
-            ValueFormat: The matched format.
+            ValueFormat: The coerced enum value.
 
         Raises:
-            ValueError: If input is not valid.
+            ValueError: If input doesn't match any label.
         """
         if isinstance(value, cls):
             return value

--- a/src/serial_protocol/utils.py
+++ b/src/serial_protocol/utils.py
@@ -186,13 +186,13 @@ def bytearray_to_decstring(data: bytearray) -> str:
     return " ".join("{:03d}".format(x) for x in data)
 
 
-def int_to_bytearray(value: int, format: ValueFormat, byteorder: str = "little") -> bytearray:
+def int_to_bytearray(value: int, format_: ValueFormat, byteorder: str = "little") -> bytearray:
     """
     Converts an integer into a bytearray based on a value format.
 
     Args:
         value (int): The integer value to convert.
-        format (format): The format type. Cannot be FLOAT32 or FLOAT64.
+        format_ (format): The format type. Cannot be FLOAT32 or FLOAT64.
         byteorder (str): Byte order ('little' or 'big'). Default is 'little'.
 
     Returns:
@@ -205,12 +205,12 @@ def int_to_bytearray(value: int, format: ValueFormat, byteorder: str = "little")
         >>> int_to_bytearray(1025, ValueFormat.UINT16)
         bytearray(b'\x01\x04')
     """
-    format = ValueFormat.coerce(format)
-    if format.is_float():
+    format_ = ValueFormat.coerce(format_)
+    if format_.is_float():
         raise ValueError("The format cannot be FLOAT32 or FLOAT64.")
-    if not (0 <= value <= format.max_value):
-        raise ValueError(f"Value must be in range [0, {format.max_value}].")
-    return bytearray(value.to_bytes(format.num_bytes, byteorder=byteorder))
+    if not (0 <= value <= format_.max_value):
+        raise ValueError(f"Value must be in range [0, {format_.max_value}].")
+    return bytearray(value.to_bytes(format_.num_bytes, byteorder=byteorder))
 
 
 def bytearray_to_int(value: bytearray, byteorder: str = "little") -> int:

--- a/tests/test_tlv.py
+++ b/tests/test_tlv.py
@@ -1,52 +1,48 @@
 #!/usr/bin/env python3
 
 import pytest
-import struct
 import random
+import math
 from itertools import product
 from serial_protocol import tlv, utils
+from hypothesis import given, strategies as st
 
 
-# --- Constructor Tests ---
+# --- CONSTRUCTOR TESTS --- #
 
-def test_tlv_packet_constructor_defaults():
+
+def test_defaults():
     packet = tlv.TLVPacket()
     assert isinstance(packet, tlv.TLVPacket)
-    assert packet.max_data_length == utils.MaxUInt.UINT8
-    assert packet.max_data_value == utils.MaxUInt.UINT8
-    assert packet.float_byte_size == utils.FloatPrecision.FLOAT32
+    assert packet.max_data_length == utils.ValueFormat.UINT8
 
 
 @pytest.mark.parametrize("attr, enumval", [
-    ("max_data_length", utils.MaxUInt.UINT16),
-    ("max_data_length", utils.MaxUInt.UINT32),
-    ("max_data_value", utils.MaxUInt.UINT16),
-    ("max_data_value", utils.MaxUInt.UINT32),
-    ("float_byte_size", utils.FloatPrecision.FLOAT64),
+    ("max_data_length", utils.ValueFormat.UINT8),
+    ("max_data_length", utils.ValueFormat.UINT16),
+    ("max_data_length", utils.ValueFormat.UINT32),
 ])
-def test_tlv_packet_constructor_valid(attr, enumval):
+def test_valid_constructor_values(attr, enumval):
     packet = tlv.TLVPacket(**{attr: enumval})
     assert getattr(packet, attr) == enumval
 
 
 @pytest.mark.parametrize("attr, value", [
     ("max_data_length", 999),
-    ("max_data_value", "UINT16"),
-    ("float_byte_size", 5),
+    ("max_data_length", "FLOAT32"),
 ])
-def test_tlv_packet_constructor_invalid(attr, value):
+def test_invalid_constructor_values(attr, value):
     with pytest.raises(ValueError):
         tlv.TLVPacket(**{attr: value})
 
 
-# --- Property Setters ---
+# --- PROPERTY TESTS --- #
+
 
 @pytest.mark.parametrize("attr, values", [
-    ("max_data_length", [utils.MaxUInt.UINT8, utils.MaxUInt.UINT16, utils.MaxUInt.UINT32]),
-    ("max_data_value", [utils.MaxUInt.UINT8, utils.MaxUInt.UINT16, utils.MaxUInt.UINT32]),
-    ("float_byte_size", [utils.FloatPrecision.FLOAT32, utils.FloatPrecision.FLOAT64]),
+    ("max_data_length", [utils.ValueFormat.UINT8, utils.ValueFormat.UINT16, utils.ValueFormat.UINT32]),
 ])
-def test_tlv_packet_property_setters(attr, values):
+def test_valid_setters(attr, values):
     packet = tlv.TLVPacket()
     for val in values:
         setattr(packet, attr, val)
@@ -54,115 +50,170 @@ def test_tlv_packet_property_setters(attr, values):
 
 
 @pytest.mark.parametrize("attr, invalid_value", [
-    ("max_data_length", 0),
-    ("max_data_value", None),
-    ("float_byte_size", "bad"),
+    ("max_data_length", "FLOAT64"),
 ])
-def test_tlv_packet_property_setters_invalid(attr, invalid_value):
+def test_invalid_setters(attr, invalid_value):
     packet = tlv.TLVPacket()
     with pytest.raises(ValueError):
         setattr(packet, attr, invalid_value)
 
 
-# --- Encode/Decode INT ---
+# --- ENCODE/DECODE TESTS --- #
 
-@pytest.mark.parametrize("max_length, max_value", product(utils.MaxUInt, utils.MaxUInt))
-def test_encode_decode_int_roundtrip(max_length, max_value):
-    packet = tlv.TLVPacket(max_data_length=max_length, max_data_value=max_value)
-    type_ = random.randint(0, 255)  # nosec
-    value_ = random.randint(0, max_value.max_value)  # nosec
-    encoded = packet.encode(type_, value_)
-    decoded = packet.decode(encoded, return_value_as=tlv.TLVValueReturnType.INT)
+
+@pytest.mark.parametrize("max_length, format_", product(
+    [utils.ValueFormat.UINT8, utils.ValueFormat.UINT16, utils.ValueFormat.UINT32],
+    [utils.ValueFormat.UINT8, utils.ValueFormat.UINT16, utils.ValueFormat.UINT32]
+))
+def test_encode_decode_int_roundtrip(max_length, format_):
+    packet = tlv.TLVPacket(max_data_length=max_length)
+    type_ = random.randint(0, 255)
+    value_ = random.randint(0, format_.max_value)
+    encoded = packet.encode(type_, value_, format_)
+    decoded = packet.decode(encoded, value_format=format_)
     assert decoded[0] == type_
     assert decoded[2] == value_
 
 
-@pytest.mark.parametrize("max_value, input_val, expected_bytes", [
-    (utils.MaxUInt.UINT8, 42, bytearray([0x01, 0x01, 0x2A])),
-    (utils.MaxUInt.UINT16, 513, bytearray([0x01, 0x02, 0x01, 0x02])),
-])
-def test_encode_int_structure(max_value, input_val, expected_bytes):
-    packet = tlv.TLVPacket(max_data_value=max_value)
-    result = packet.encode(1, input_val)
-    assert result == expected_bytes
-
-
-@pytest.mark.parametrize("packet_bytes, expected_value", [
-    (bytearray([0x01, 0x01, 0x2A]), 42),
-    (bytearray([0x01, 0x02, 0x01, 0x02]), 513),
-])
-def test_decode_int_structure(packet_bytes, expected_value):
-    packet = tlv.TLVPacket()
-    result = packet.decode(packet_bytes, return_value_as=tlv.TLVValueReturnType.INT)
-    assert result == (1, len(packet_bytes) - 2, expected_value)
-
-
-
-# --- Encode/Decode FLOAT ---
-
-@pytest.mark.parametrize("max_length, float_prec", product(utils.MaxUInt, utils.FloatPrecision))
-def test_encode_decode_float_roundtrip(max_length, float_prec):
-    packet = tlv.TLVPacket(max_data_length=max_length, float_byte_size=float_prec)
+@pytest.mark.parametrize("max_length, format_", product(
+    [utils.ValueFormat.UINT8, utils.ValueFormat.UINT16, utils.ValueFormat.UINT32],
+    [utils.ValueFormat.FLOAT32, utils.ValueFormat.FLOAT64],
+))
+def test_encode_decode_float_roundtrip(max_length, format_):
+    packet = tlv.TLVPacket(max_data_length=max_length)
     type_ = 42
     value_ = 3.14
-    encoded = packet.encode(type_, value_)
-    decoded = packet.decode(encoded, return_value_as=tlv.TLVValueReturnType.FLOAT)
+    encoded = packet.encode(type_, value_, format_)
+    decoded = packet.decode(encoded, value_format=format_)
     assert decoded[0] == type_
     assert round(decoded[2], 2) == round(value_, 2)
 
 
-def test_encode_float32_structure():
-    packet = tlv.TLVPacket(float_byte_size=utils.FloatPrecision.FLOAT32)
-    result = packet.encode(1, 3.14)
-    expected = bytearray([0x01, 0x04]) + struct.pack('f', 3.14)
-    assert result == expected
+def test_raw_bytearray_decode():
+    packet = tlv.TLVPacket()
+    value_bytes = bytearray([0xAB, 0xCD])
+    length = len(value_bytes)
+    length_bytes = utils.int_to_bytearray(length, format=utils.ValueFormat.UINT8)
+    encoded = bytearray([0x05]) + length_bytes + value_bytes
+    decoded = packet.decode(encoded, value_format=None)
+    assert decoded == (5, length, value_bytes)
 
 
-def test_decode_float32_structure():
-    bytes_ = bytearray([0x01, 0x04]) + struct.pack('f', 3.14)
-    packet = tlv.TLVPacket(float_byte_size=utils.FloatPrecision.FLOAT32)
-    result = packet.decode(bytes_, return_value_as=tlv.TLVValueReturnType.FLOAT)
-    assert round(result[2], 2) == 3.14
+# --- ERROR TESTS --- #
 
 
-# --- Type/Value Error Handling ---
+def test_decode_length_mismatch():
+    packet = tlv.TLVPacket(max_data_length=utils.ValueFormat.UINT8)
+    corrupted = bytearray([0x01, 0x05, 0xAA])  # claims length 5, gives 1 byte
+    with pytest.raises(ValueError):
+        packet.decode(corrupted, value_format=None)
+
 
 @pytest.mark.parametrize("invalid_type", [-1, 256, 3.14, "str", None])
-def test_encode_invalid_type(invalid_type):
+def test_invalid_type_input(invalid_type):
     packet = tlv.TLVPacket()
     with pytest.raises((TypeError, ValueError)):
-        packet.encode(invalid_type, 1)
+        packet.encode(invalid_type, 1, utils.ValueFormat.UINT8)
 
 
 @pytest.mark.parametrize("invalid_value", ["abc", {}, [1], (2,), None])
-def test_encode_invalid_value(invalid_value):
+def test_invalid_value_input(invalid_value):
     packet = tlv.TLVPacket()
     with pytest.raises(TypeError):
-        packet.encode(1, invalid_value)
+        packet.encode(1, invalid_value, utils.ValueFormat.UINT8)
 
 
-@pytest.mark.parametrize("invalid_float", [
-    bytearray([0x00, 0x00]),          # too short
-    bytearray([0x00] * 10),           # too long
-])
-def test_decode_float_size_mismatch(invalid_float):
-    packet = tlv.TLVPacket(float_byte_size=utils.FloatPrecision.FLOAT32)
-    length_bytes = utils.int_to_bytearray(len(invalid_float), packet.max_data_length)
-    full_packet = bytearray([0x01]) + length_bytes + invalid_float
+def test_encode_float_with_uint_format():
+    packet = tlv.TLVPacket()
+    with pytest.raises(TypeError):
+        packet.encode(1, 3.14, utils.ValueFormat.UINT16)
+
+
+def test_encode_int_out_of_range():
+    packet = tlv.TLVPacket()
     with pytest.raises(ValueError):
-        packet.decode(full_packet, return_value_as=tlv.TLVValueReturnType.FLOAT)
+        packet.encode(1, 256, utils.ValueFormat.UINT8)
 
 
-def test_decode_empty_packet_raises():
+def test_decode_float_size_mismatch():
+    packet = tlv.TLVPacket()
+    format_ = utils.ValueFormat.FLOAT32
+    bad_float = bytearray([0x00, 0x00])  # Too short
+    length = utils.int_to_bytearray(len(bad_float), format=utils.ValueFormat.UINT8)
+    full = bytearray([0x01]) + length + bad_float
+    with pytest.raises(ValueError):
+        packet.decode(full, value_format=format_)
+
+
+def test_decode_empty_packet():
     packet = tlv.TLVPacket()
     with pytest.raises(ValueError):
         packet.decode(bytearray([]))
 
 
-def test_decode_type_error_inputs():
+def test_decode_type_error():
     packet = tlv.TLVPacket()
     with pytest.raises(TypeError):
-        packet.decode("not a bytearray")
+        packet.decode("not bytes")
 
-    with pytest.raises(TypeError):
-        packet.decode(bytearray([0x01, 0x00]), return_value_as="string")
+
+# --- UINT FUZZ TESTS --- #
+
+uint_strategies = {
+    utils.ValueFormat.UINT8: st.integers(min_value=0, max_value=2**8 - 1),
+    utils.ValueFormat.UINT16: st.integers(min_value=0, max_value=2**16 - 1),
+    utils.ValueFormat.UINT32: st.integers(min_value=0, max_value=2**32 - 1),
+}
+
+
+@pytest.mark.parametrize("format_", [utils.ValueFormat.UINT8, utils.ValueFormat.UINT16, utils.ValueFormat.UINT32])
+@given(type_=st.integers(min_value=0, max_value=255),
+       data=st.integers(min_value=0, max_value=2**32 - 1))
+def test_fuzz_encode_decode_uints(type_, data, format_):
+    if data > format_.max_value:
+        pytest.skip("Filtered to avoid over-range value for format")
+    packet = tlv.TLVPacket(max_data_length=utils.ValueFormat.UINT8)
+    encoded = packet.encode(type_, data, format_)
+    decoded = packet.decode(encoded, value_format=format_)
+    assert decoded[0] == type_
+    assert decoded[2] == data
+
+
+# --- FLOAT FUZZ TESTS --- #
+
+@given(
+    type_=st.integers(min_value=0, max_value=255),
+    data=st.floats(
+        min_value=-3.4e38,
+        max_value=3.4e38,
+        allow_nan=False,
+        allow_infinity=False,
+        width=64
+    )
+)
+def test_fuzz_encode_decode_float32(type_, data):
+    format_ = utils.ValueFormat.FLOAT32
+    packet = tlv.TLVPacket(max_data_length=utils.ValueFormat.UINT8)
+    encoded = packet.encode(type_, data, format_)
+    decoded = packet.decode(encoded, value_format=format_)
+    assert decoded[0] == type_
+    assert math.isclose(decoded[2], data, rel_tol=1e-5, abs_tol=1e-5)
+
+
+@given(
+    type_=st.integers(min_value=0, max_value=255),
+    data=st.floats(
+        min_value=-1.7e308,
+        max_value=1.7e308,
+        allow_nan=False,
+        allow_infinity=False,
+        width=64
+    )
+)
+def test_fuzz_encode_decode_float64(type_, data):
+    format_ = utils.ValueFormat.FLOAT64
+    packet = tlv.TLVPacket(max_data_length=utils.ValueFormat.UINT8)
+    encoded = packet.encode(type_, data, format_)
+    decoded = packet.decode(encoded, value_format=format_)
+    assert decoded[0] == type_
+    assert math.isclose(decoded[2], data, rel_tol=1e-5, abs_tol=1e-5)

--- a/tests/test_tlv.py
+++ b/tests/test_tlv.py
@@ -93,7 +93,7 @@ def test_raw_bytearray_decode():
     packet = tlv.TLVPacket()
     value_bytes = bytearray([0xAB, 0xCD])
     length = len(value_bytes)
-    length_bytes = utils.int_to_bytearray(length, format=utils.ValueFormat.UINT8)
+    length_bytes = utils.int_to_bytearray(length, format_=utils.ValueFormat.UINT8)
     encoded = bytearray([0x05]) + length_bytes + value_bytes
     decoded = packet.decode(encoded, value_format=None)
     assert decoded == (5, length, value_bytes)
@@ -139,7 +139,7 @@ def test_decode_float_size_mismatch():
     packet = tlv.TLVPacket()
     format_ = utils.ValueFormat.FLOAT32
     bad_float = bytearray([0x00, 0x00])  # Too short
-    length = utils.int_to_bytearray(len(bad_float), format=utils.ValueFormat.UINT8)
+    length = utils.int_to_bytearray(len(bad_float), format_=utils.ValueFormat.UINT8)
     full = bytearray([0x01]) + length + bad_float
     with pytest.raises(ValueError):
         packet.decode(full, value_format=format_)

--- a/tests/test_tlv.py
+++ b/tests/test_tlv.py
@@ -67,8 +67,8 @@ def test_invalid_setters(attr, invalid_value):
 ))
 def test_encode_decode_int_roundtrip(max_length, format_):
     packet = tlv.TLVPacket(max_data_length=max_length)
-    type_ = random.randint(0, 255)
-    value_ = random.randint(0, format_.max_value)
+    type_ = random.randint(0, 255)  #nosec
+    value_ = random.randint(0, format_.max_value)  #nosec
     encoded = packet.encode(type_, value_, format_)
     decoded = packet.decode(encoded, value_format=format_)
     assert decoded[0] == type_

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_bytearray_to_decstring():
 
 
 # --- Integer Conversion ---
-@pytest.mark.parametrize("value, format, expected", [
+@pytest.mark.parametrize("value, format_, expected", [
     (0, utils.ValueFormat.UINT8, bytearray([0x00])),
     (8, utils.ValueFormat.UINT8, bytearray([0x08])),
     (255, utils.ValueFormat.UINT8, bytearray([0xFF])),
@@ -78,8 +78,8 @@ def test_bytearray_to_decstring():
     (8, utils.ValueFormat.UINT32, bytearray([0x08, 0x00, 0x00, 0x00])),
     (4294967295, utils.ValueFormat.UINT32, bytearray([0xFF, 0xFF, 0xFF, 0xFF]))
 ])
-def test_int_to_bytearray(value, format, expected):
-    assert utils.int_to_bytearray(value, format) == expected
+def test_int_to_bytearray(value, format_, expected):
+    assert utils.int_to_bytearray(value, format_) == expected
 
 
 @pytest.mark.parametrize("value, max_value", [


### PR DESCRIPTION
- Added tlv.py to sphinx documentation
- Refactored encode/decode to take a format as an argument rather than having it as part of the TLV class
- Refactored MaxUint and FloatPrecision enums into single ValueFormat enum